### PR TITLE
Update IOS ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: ./gradlew :androidApp:assembleDebug
 
   build-ios:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: 17
 
       - name: Build iOS app
-        run: xcodebuild -workspace iosApp/iosApp.xcodeproj/project.xcworkspace -configuration Debug -scheme iosApp -sdk iphonesimulator
+        run: xcodebuild -workspace iosApp/iosApp.xcodeproj/project.pbxproj -configuration Debug -scheme iosApp -sdk iphonesimulator
 
   build-jvm:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: 17
 
       - name: Build iOS app
-        run: xcodebuild -allowProvisioningUpdates -project iosApp/iosApp.xcodeproj -configuration Debug -scheme iosApp -sdk iphoneos -destination name='iPhone 14' build
+        run: xcodebuild -workspace iosApp/iosApp.xcodeproj/project.xcworkspace -configuration Debug -scheme iosApp -sdk iphonesimulator
 
   build-jvm:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: 17
 
       - name: Build iOS app
-        run: xcodebuild -workspace iosApp/iosApp.xcodeproj/project.pbxproj -configuration Debug -scheme iosApp -sdk iphonesimulator
+        run: xcodebuild -allowProvisioningUpdates -project iosApp/iosApp.xcodeproj -configuration Debug -scheme iosApp -sdk iphonesimulator
 
   build-jvm:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This pull request includes updates to the CI configuration in the `.github/workflows/ci.yml` file to ensure compatibility with the latest environments and improve the build process.

CI configuration updates:

* Updated the `runs-on` parameter for the `build-ios` job to use `macos-latest` instead of a specific macOS version.
* Modified the `run` command for building the iOS app to use the iPhone simulator SDK instead of the iPhone OS SDK.