### PR TITLE
Change update schedule to monthly for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     assignees:
       - "GuillemRoca"


### PR DESCRIPTION
This pull request modifies the Dependabot configuration to reduce the frequency of dependency updates for the Gradle package ecosystem.

Configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-R11): Changed the update schedule for the Gradle package ecosystem from "daily" to "monthly" to reduce the frequency of dependency updates.